### PR TITLE
Standardize log prefix with utils helper.

### DIFF
--- a/dev/app-shell/app-shell.html
+++ b/dev/app-shell/app-shell.html
@@ -192,7 +192,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </template>
 
 <script>
-  const logPre = [`%cAppShell`, `background: #007ac1; color: white; padding: 1px 6px 2px 8px; border-radius: 6px;`];
+  const logPre = Arcs.utils.prettyLogPrefix('AppShell', '#007ac1');
   const log = console.log.bind(console, ...logPre);
 
   class AppShell extends HTMLElement {

--- a/dev/app-shell/lib/cast-tools.js
+++ b/dev/app-shell/lib/cast-tools.js
@@ -10,8 +10,8 @@
 
 (() => {
 
-const castLog = `background: #f57f17; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`;
-const log = console.log.bind(console, '%cCastTools', castLog);
+const pre = Arcs.utils.prettyLogPrefix('CastTools', '#f57f17');
+const log = console.log.bind(console, ...pre);
 
 let CastTools = {
   async init() {

--- a/dev/app-shell/lib/metadata-storage.js
+++ b/dev/app-shell/lib/metadata-storage.js
@@ -10,8 +10,7 @@
 
 (function(scope) {
 
-  //const storeLog = `background: #c43e00; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`;
-  const pre = [`%cMetadataStorage`, `background: #c43e00; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`];
+  const pre = Arcs.utils.prettyLogPrefix('MetadataStorage', '#c43e00');
   const log = console.log.bind(console, ...pre);
   const assert = console.assert.bind(console, ...pre);
   const warn = console.warn.bind(console, ...pre);
@@ -49,7 +48,7 @@
       // TODO(noelutz): do we need to keep track of multiple keys if the same
       // Arc is imported twice (e.g., both as friend and profile Arc)?
       if (this._watchedArcs[key]) {
-        this._watchedArcs[key].push(watchedArc);  
+        this._watchedArcs[key].push(watchedArc);
       } else {
         this._watchedArcs[key] = [watchedArc];
       }
@@ -129,7 +128,7 @@
           } else {
             localView.clear();
           }
-        });  
+        });
       }
       return {id: viewId, node: remoteView};
     }

--- a/dev/app-shell/lib/sharing-tools.js
+++ b/dev/app-shell/lib/sharing-tools.js
@@ -10,7 +10,7 @@
 
 (function(scope) {
 
-const pre = [`%cSharingTools`, `background: #005b4f; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`];
+const pre = Arcs.utils.prettyLogPrefix('SharingTools', '#005b4f');
 const log = console.log.bind(console, ...pre);
 
 /*
@@ -78,7 +78,7 @@ SharingTools = {
       this._watchProfileArcs(user, watches);
       // Setup the watches
       log(`watchSharedArcs `, watches);
-      StorageTools.shared.watchAll(watches, () => this._shell.viewsChanged());      
+      StorageTools.shared.watchAll(watches, () => this._shell.viewsChanged());
       ProfileWatcher.watch(user, () => this._shell.viewsChanged());
     }
   },

--- a/dev/app-shell/lib/storage-tools.js
+++ b/dev/app-shell/lib/storage-tools.js
@@ -10,7 +10,7 @@
 
 ((scope) => {
 
-const pre = [`%cStorageTools`, `background: #280680; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`];
+const pre = Arcs.utils.prettyLogPrefix('StorageTools', '#280680');
 const log = console.log.bind(console, ...pre);
 const warn = console.warn.bind(console, ...pre);
 

--- a/dev/app-shell/lib/user-tools.js
+++ b/dev/app-shell/lib/user-tools.js
@@ -10,8 +10,8 @@
 
 (function(scope) {
 
-const userLog = `background: #20AA20; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`;
-const log = console.log.bind(console, '%cUserTools', userLog);
+const pre = Arcs.utils.prettyLogPrefix('UserTools', '#20AA20');
+const log = console.log.bind(console, ...pre);
 
 UserTools = {
   async init(config, arc, loader) {

--- a/dev/app-shell/lib/utils.js
+++ b/dev/app-shell/lib/utils.js
@@ -76,6 +76,9 @@ let utils = {
     let url = new URL(document.location.href);
     url.searchParams.set(name, value);
     window.history.replaceState({}, "", decodeURIComponent(url.href));
+  },
+  prettyLogPrefix(moduleName, backgroundColor) {
+    return [`%c${moduleName}`, `background: ${backgroundColor}; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`];
   }
 };
 


### PR DESCRIPTION
I was looking for a trivial change to go through the overall workflow and this seemed like a ready candidate.

It would be great if we had basic unit tests for the app shell. Maybe I can look at doing something rudimentary there soon. For now I tested manually by reloading the app shell hosted locally, reviewing the console, and seeing whether things appeared operational. If there's something else I should do let me know.

I also did not replace a log prefix in:

https://github.com/PolymerLabs/arcs-cdn/blob/gh-pages/dev/source/worker-entry-cdn.js#L14

as I don't think utils.js is available in that context.