### PR TITLE
Keep using prettyLogPrefix for metadata storage log.

### DIFF
--- a/dev/app-shell/lib/metadata-storage.js
+++ b/dev/app-shell/lib/metadata-storage.js
@@ -9,9 +9,7 @@
  */
 
 (function(scope) {
-
-  //const storeLog = `background: #c43e00; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`;
-  const pre = [`%cMetadataStorage`, `background: #c43e00; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`];
+  const pre = Arcs.utils.prettyLogPrefix('MetadataStorage', '#c43e00');
   const log = console.log.bind(console, ...pre);
   const assert = console.assert.bind(console, ...pre);
   const warn = console.warn.bind(console, ...pre);


### PR DESCRIPTION
Trivial restore of what looks like an accidental revert as part of:

https://github.com/PolymerLabs/arcs-cdn/commit/f4ee7eea41a05f229bbdf0d7063c43cd2bd8acf8

I also noted XenBase.logFactory which is basically the same as what we're doing in utils but maybe we like not being tied to Xen for this sort of thing, or we can merge later.