### PR TITLE
check that we could find a view before clearing it

### DIFF
--- a/v0.2.1/app-shell/lib/metadata-storage.js
+++ b/v0.2.1/app-shell/lib/metadata-storage.js
@@ -105,7 +105,9 @@
         return;
       }
       let v = this._arc.context.findViewById(viewId);
-      if (v && v.toList) {
+      if (!v) {
+        log(`couldn't find view ${viewId} to clear`);
+      } else if (v.toList) {
         v.toList().forEach(e => {
           v.remove(e.id);
         });

--- a/v0.2.1/app-shell/lib/metadata-storage.js
+++ b/v0.2.1/app-shell/lib/metadata-storage.js
@@ -105,7 +105,7 @@
         return;
       }
       let v = this._arc.context.findViewById(viewId);
-      if (v.toList) {
+      if (v && v.toList) {
         v.toList().forEach(e => {
           v.remove(e.id);
         });


### PR DESCRIPTION
I started seeing errors (I think) due to a stale view reference (to
shared:PROFILE/[Post]/posts/) causing errors here.

@noelutz let me know if this makes sense, or if you'd like to debug my state further instead.