### PR TITLE
request injection of arcs data after we've added the event listener

### DIFF
--- a/v0.2.1/apps/chrome-extension/index.html
+++ b/v0.2.1/apps/chrome-extension/index.html
@@ -68,11 +68,6 @@
         await super._start(config);
         var appshell = this;
 
-        // The content script handles this, but that could have happened
-        // before we added our event listener below. Let's ask the content
-        // script to trigger again now that we're ready.
-        window.postMessage({method: 'pleaseInjectArcsData'}, '*');
-
         window.addEventListener('message', event => {
           easLog(`received event ${event.data.method} from ${event.source}`,
               event.data, config);
@@ -141,6 +136,17 @@
             });
           });
         }, false);
+
+        // The content script handles this, but that could have happened
+        // before we added our event listener below. Let's ask the content
+        // script to trigger again now that we're ready.
+        // This must be after the reloadManifests() call above - before then
+        // we end up in race conditions (lots of errors about uninitialized
+        // views) because the callback is called too soon.
+        // TODO I'm not sure I fully understand why, though. I'm worried it's
+        // working not because it's correct but because I've narrowed the
+        // unlucky window. As we get more users this should become clearer.
+        window.postMessage({method: 'pleaseInjectArcsData'}, '*');
       }
     }
 


### PR DESCRIPTION
Without this, there seems to be a race condition that's triggered often.
I'm concerned (as mentioned in a TODO) that this change narrows the
window for the race instead of removing it, but wider testing and more
eyes will help illuminate this.
For now this may be better but not best.