### PR TITLE
'name' fields should be restricted to values (not lists)

### DIFF
--- a/v0.2.1/apps/chrome-extension/index.html
+++ b/v0.2.1/apps/chrome-extension/index.html
@@ -127,7 +127,19 @@
               let filteredEntities = entities.map(entity => Object.entries(entity)
                   .filter(entry => validSchemaKeys.includes(entry[0]))
                   .reduce((result,current) => {
-                    result[current[0]] = current[1];
+                    let key = current[0];
+
+                    // do some basic filtering on values.
+                    // TODO(smalls) as we discover more cases that need this,
+                    // let's pull this out into something more maintanable.
+                    let value;
+                    if (key=='name' && Array.isArray(current[1])) {
+                      value = current[1][0];
+                    } else {
+                      value = current[1];
+                    }
+
+                    result[key] = value;
                     return result;
                   }, {})
               );


### PR DESCRIPTION
When we see a list for name, use the first element.
This is allowed so we should support it better; but, it's not clear right now
how to do that (and if we'll continue allowing all fields to be lists).