### PR TITLE
when consolidating by type, normalize urls to 'http'

### DIFF
--- a/v0.2.1/apps/chrome-extension/data-processing.js
+++ b/v0.2.1/apps/chrome-extension/data-processing.js
@@ -18,6 +18,12 @@ function flatten(entities) {
   return Object.entries(entities).reduce((accumulator, [key, value]) => {
     value.forEach(entry => {
       let type = entry['@type'];
+
+      // normalize all https? urls to http in keys
+      if (type.match(/^https?:\/\//)) {
+        type = type.replace(/^https?:/, 'http:');
+      }
+
       accumulator[type]
         ? accumulator[type].push(entry)
         : (accumulator[type] = [entry]);

--- a/v0.2.1/apps/chrome-extension/test/data-processing-test.js
+++ b/v0.2.1/apps/chrome-extension/test/data-processing-test.js
@@ -53,6 +53,31 @@ describe('ChromeExtensionDataProcessing', function() {
       let result = flatten(sample);
       assert.deepEqual(result, expected);
     });
+    it('should flatten & combine datatypes ignore https', function() {
+      let sample = {
+        'https://my/great/site': [
+          { '@type': 'https://TypeA', name: 'TypeA_MGS' },
+          { '@type': 'https://TypeB', name: 'TypeB_MGS' }
+        ],
+        'http://my/terrible/site': [
+          { '@type': 'http://TypeA', name: 'TypeA_MTS' },
+          { '@type': 'http://TypeB', name: 'TypeB_MTS' }
+        ]
+      };
+      let expected = {
+        'http://TypeA': [
+          { '@type': 'https://TypeA', name: 'TypeA_MGS' },
+          { '@type': 'http://TypeA', name: 'TypeA_MTS' }
+        ],
+        'http://TypeB': [
+          { '@type': 'https://TypeB', name: 'TypeB_MGS' },
+          { '@type': 'http://TypeB', name: 'TypeB_MTS' }
+        ]
+      };
+
+      let result = flatten(sample);
+      assert.deepEqual(result, expected);
+    });
   });
   describe('#deduplicate()', function() {
     it('should deduplicate', function() {


### PR DESCRIPTION
This avoids the case where http://schema.org/Product and
https://schema.org/Products would be treated as different types by the
extension.