### PR TITLE
ensure that entities passed to Arcs pass a basic sanity check

### DIFF
--- a/v0.2.1/apps/chrome-extension/data-processing.js
+++ b/v0.2.1/apps/chrome-extension/data-processing.js
@@ -6,6 +6,22 @@
 // http://polymer.github.io/PATENTS.txt
 
 /**
+ * There are some entity shapes that aren't yet supported by Arcs. Ensure that:
+ *  - There is a 'name' field.
+ */
+function filter(entities) {
+  return Object.entries(entities).reduce((accumulator, [key, values]) => {
+    accumulator[key] = values.reduce((accumulator, value) => {
+      if (value.hasOwnProperty('name')) {
+        accumulator.push(value);
+      }
+      return accumulator;
+    }, []);
+    return accumulator;
+  }, new Object());
+}
+
+/**
  * Reduce the deeply nested structure of url=>entities-of-many-types to a
  * flatter, combined form of type=>entities.
  *
@@ -32,8 +48,11 @@ function flatten(entities) {
   }, new Object());
 }
 
-function deepIsEqual(a, b) {
-  return JSON.stringify(a)==JSON.stringify(b);
+/** Returns true iff a & b are pointers to the same object, or if their naive
+ * JSON representations (without sorting) are the same. {a, b} != {b, a}.
+ */
+function _deepIsEqual(a, b) {
+  return a === b || JSON.stringify(a) == JSON.stringify(b);
 }
 
 /**
@@ -44,7 +63,7 @@ function deduplicate(entities) {
   return Object.entries(entities).reduce((accumulator, [key, values]) => {
     accumulator[key] = values.reduce((accumulator, value) => {
       let isIncluded = accumulator.reduce(
-        (a, av) => deepIsEqual(av, value) || a,
+        (a, av) => _deepIsEqual(av, value) || a,
         false
       );
       isIncluded || accumulator.push(value);

--- a/v0.2.1/apps/chrome-extension/index.html
+++ b/v0.2.1/apps/chrome-extension/index.html
@@ -75,9 +75,9 @@
             return;
           }
 
-          // TODO(smalls) This should be replaced with transformations done in
-          // particles.
-          let dataByType = deduplicate(flatten(event.data.entities));
+          // TODO(smalls) Should these be replaced with Transformation
+          // particles?
+          let dataByType = deduplicate(flatten(filter(event.data.entities)));
 
           if (dataByType['text/x-arcs-manifest']) {
             config.additionalManifests = dataByType['text/x-arcs-manifest'].map(m => m.url);

--- a/v0.2.1/apps/chrome-extension/test/data-processing-test.js
+++ b/v0.2.1/apps/chrome-extension/test/data-processing-test.js
@@ -12,8 +12,27 @@ afterEach(function() {
 });
 
 describe('ChromeExtensionDataProcessing', function() {
+  describe('#filter', function() {
+    it('should skip entities without a name', function() {
+      let sample = {
+        'https://my/great/site': [{ '@type': 'http://TypeA' }],
+        'http://my/terrible/site': [
+          { '@type': 'http://TypeA', name: 'TypeA_MTS' }
+        ]
+      };
+      let expected = {
+        'https://my/great/site': [],
+        'http://my/terrible/site': [
+          { '@type': 'http://TypeA', name: 'TypeA_MTS' }
+        ]
+      };
+
+      let result = filter(sample);
+      assert.deepEqual(result, expected);
+    });
+  });
   describe('#flatten()', function() {
-    it('should flatten & combine single datatype', function() {
+    it('should organize entities by data type', function() {
       let sample = {
         'http://my/great/site': [{ '@type': 'TypeA', name: 'TypeA_MGS' }],
         'http://my/terrible/site': [{ '@type': 'TypeA', name: 'TypeA_MTS' }]
@@ -28,7 +47,7 @@ describe('ChromeExtensionDataProcessing', function() {
       let result = flatten(sample);
       assert.deepEqual(result, expected);
     });
-    it('should flatten & combine datatypes', function() {
+    it('should organize entities by data type (multiple data types should be kept separate)', function() {
       let sample = {
         'http://my/great/site': [
           { '@type': 'TypeA', name: 'TypeA_MGS' },
@@ -53,7 +72,7 @@ describe('ChromeExtensionDataProcessing', function() {
       let result = flatten(sample);
       assert.deepEqual(result, expected);
     });
-    it('should flatten & combine datatypes ignore https', function() {
+    it('should ignore http vs https', function() {
       let sample = {
         'https://my/great/site': [
           { '@type': 'https://TypeA', name: 'TypeA_MGS' },


### PR DESCRIPTION
Currently, that they at least have a 'name' field.

This opens up some new sites (like Home Depot) to Arcs. For instance, https://www.homedepot.com/p/Milwaukee-46-in-18-Drawer-Tool-Chest-and-Cabinet-Combo-48-22-8546/301937094 had several products with missing name fields that would cause some particles to crash.