### PR TITLE
split commands apart into multiple lines (instead of &&) for clarity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@ language: node_js
 node_js:
   - "9"
 before_script:
+  - npm install
   - node_modules/http-server/bin/http-server -a localhost -p 8080 &
   - sleep 3
-script: "npm install && npm test"
+script:
+  - npm install
+  - npm test
 branches:
   only:
     - gh-pages


### PR DESCRIPTION
Also make `npm install` commands explicit; travis was running one
automatically before `http-server`, but I'm not sure why.