### PR TITLE
Support launching arcs created with solo/manifest recipes.

### DIFF
--- a/dev/app-shell/elements/arc-app.html
+++ b/dev/app-shell/elements/arc-app.html
@@ -447,12 +447,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (user) {
         let data = Object.keys(visited).map(key => {
           let {metadata, profile} = visited[key];
+          let href = `${location.origin}${location.pathname}?arc=${key}&user=${user.id}`;
+          if (metadata.additionalRecipe) href += `&manifest=${metadata.additionalRecipe}`;
           return {
             key: key,
             description: metadata.description || key.slice(1),
             icon: metadata.icon || 'broken_image',
             color: metadata.color || 'gray',
-            href: `${location.origin}${location.pathname}?arc=${key}&user=${user.id}`,
+            href: href,
             profile: Boolean(profile)
           };
         });

--- a/dev/app-shell/elements/persistent-arc.html
+++ b/dev/app-shell/elements/persistent-arc.html
@@ -16,16 +16,36 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         db: db.child('arcs')
       };
     }
+    // Allow overriding search params for unit tests.
+    _getSearchParams() {
+      return (new URL(document.location)).searchParams;
+    }
+    _getExternalManifest() {
+      const params = this._getSearchParams();
+      // Prioritize manifest over solo, semi-arbitrarily, since usually we'll
+      // only see one or the other.
+      return params.get('solo') || params.get('manifest');
+    }
     _update(props, state, lastProps) {
       if (props.key === '*' && lastProps.key != props.key) {
         this._createKey(state.db);
       }
       if (props.key && props.key !== '*') {
-        if (props.metadata && props.metadata !== state.metadata) {
-          state.metadata = props.metadata;
-          let arcMetadata = state.db.child(props.key).child('metadata');
-          PersistentArc.log('WRITING (update) metadata for', String(arcMetadata), props.metadata);
-          arcMetadata.update(props.metadata);
+        if (props.metadata) {
+          // Typical developer workflow involves creating a new arc and
+          // subsequently modifying the url to include a specific recipe via a
+          // solo or manifest query param, thus we have to look for such a param
+          // at arc update time. Alternatively we could have the developer
+          // include the param in the main launcher page and have the app shell
+          // pass it along to the 'New Arc' url, but that is not the current
+          // state of the world.
+          props.metadata['externalManifest'] = this._getExternalManifest();
+          if (props.metadata !== state.metadata) {
+            state.metadata = props.metadata;
+            let arcMetadata = state.db.child(props.key).child('metadata');
+            PersistentArc.log('WRITING (update) metadata for', String(arcMetadata), props.metadata);
+            arcMetadata.update(props.metadata);
+          }
         }
         if (props.key !== lastProps.key) {
           state.watch.watches = [this._watchKey(state.db, props.key)];
@@ -38,7 +58,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let data = {
         description: Arcs.utils.randomName(),
         icon: icons[Math.floor(Math.random()*icons.length)],
-        color: colors[Math.floor(Math.random()*colors.length)]
+        color: colors[Math.floor(Math.random()*colors.length)],
+        externalManifest: this._getExternalManifest()
       };
       let key = db.push({'metadata': data}).key;
       this._setState({key});

--- a/dev/app-shell/elements/test/fake-database-test.js
+++ b/dev/app-shell/elements/test/fake-database-test.js
@@ -1,0 +1,93 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+var assert = chai.assert;
+
+afterEach(function() {
+  db.reset();
+});
+
+describe('FakeDatabase', function() {
+  const db = new FakeDatabase();
+
+  describe('#child', function() {
+    it('should create and cache top level child', function() {
+      const fooDatabase = db.child('foo');
+      assert.isNotNull(fooDatabase);
+      assert.equal(db.child('foo'), fooDatabase);
+      assert.equal(db.child('foo'), fooDatabase);
+    });
+
+    it('should create and cache nested children', function() {
+      const fooDatabase = db.child('foo');
+      const barDatabase = db.child('foo').child('bar');
+      const bazDatabase = db
+        .child('foo')
+        .child('bar')
+        .child('baz');
+      const schminkDatabase = db.child('foo').child('schmink');
+      assert.isNotNull(fooDatabase);
+      assert.isNotNull(barDatabase);
+      assert.isNotNull(bazDatabase);
+      assert.isNotNull(schminkDatabase);
+
+      assert.equal(db.child('foo').child('bar'), barDatabase);
+      assert.equal(db.child('foo'), fooDatabase);
+      assert.equal(db.child('foo').child('bar'), barDatabase);
+      assert.equal(
+        db
+          .child('foo')
+          .child('bar')
+          .child('baz'),
+        bazDatabase
+      );
+      assert.equal(db.child('foo').child('schmink'), schminkDatabase);
+    });
+  });
+
+  describe('#push', function() {
+    it('should support pushing values', function() {
+      assert.equal(db.push({ a: 1, b: 2 }).key, 1);
+      assert.equal(db.push({ a: 1, b: 2 }).key, 2);
+      assert.equal(db.push({ c: 3, d: 4 }).key, 3);
+    });
+  });
+
+  describe('#update', function() {
+    it('should support update and remember the last update values', function() {
+      const values = { a: 1 };
+      db.update(values);
+      assert.equal(db.lastUpdate, values);
+    });
+  });
+
+  describe('#reset', function() {
+    it('should support resetting database state', function() {
+      const fooDatabase = db.child('foo');
+      assert.isNotNull(db.child('foo'));
+      assert.equal(db.child('foo'), fooDatabase);
+
+      assert.equal(db.push({ a: 1, b: 2 }).key, 1);
+      assert.equal(db.push({ a: 1, b: 2 }).key, 2);
+
+      const values = { a: 1 };
+      db.update(values);
+      assert.equal(db.lastUpdate, values);
+
+      db.reset();
+
+      const fooDatabase2 = db.child('foo');
+      assert.isNotNull(db.child('foo'));
+      assert.notEqual(fooDatabase2, fooDatabase);
+
+      assert.equal(db.push({ a: 1, b: 2 }).key, 1);
+      assert.isUndefined(db.lastUpdate);
+      db.update(values);
+      assert.equal(db.lastUpdate, values);
+    });
+  });
+});

--- a/dev/app-shell/elements/test/fake-database.js
+++ b/dev/app-shell/elements/test/fake-database.js
@@ -1,0 +1,56 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+// A trivially simple fake database to stub out interactions with a Firebase
+// database store globally defined under the `db` symbol.
+//
+// TODO(wkorman): Currently there's no real support for retrieving values other
+// than via #lastUpdate. We could consider using something like the
+// firebase-mock-v3 npm package instead, or, further enhance this fake.
+class FakeDatabase {
+  constructor(key, data) {
+    this.reset();
+    if (key) this._key = key;
+    if (data) this._data = data;
+  }
+  child(key) {
+    if (!this._fakeChildren[key])
+      this._fakeChildren[key] = new FakeDatabase(
+        this._key + '/' + key,
+        this._data[key]
+      );
+    return this._fakeChildren[key];
+  }
+  on() {}
+  off() {}
+  push(values) {
+    const newKey = FakeDatabase.nextId();
+    this._data[newKey] = values;
+    return { key: newKey };
+  }
+  update(values) {
+    this._lastUpdate = values;
+  }
+  reset() {
+    this._key = 0;
+    this._data = {};
+    FakeDatabase._nextKey = 1;
+    this._lastUpdate = undefined;
+    this._fakeChildren = {};
+  }
+  get lastUpdate() {
+    return this._lastUpdate;
+  }
+
+  static nextId() {
+    return FakeDatabase._nextKey++;
+  }
+}
+
+FakeDatabase._nextKey = 1;
+
+const db = new FakeDatabase();

--- a/dev/app-shell/elements/test/persistent-arc-test.js
+++ b/dev/app-shell/elements/test/persistent-arc-test.js
@@ -1,0 +1,114 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+var assert = chai.assert;
+
+afterEach(function() {
+  target.innerHTML = '';
+  db.reset();
+});
+
+describe('PersistentArc', function() {
+  class TestPersistentArc extends PersistentArc {
+    constructor(element) {
+      super(element);
+      this._searchParams = new URLSearchParams(document.location.search);
+    }
+
+    _getSearchParams() {
+      return this._searchParams;
+    }
+
+    setSearchParam(key, value) {
+      this._searchParams.set(key, value);
+    }
+  }
+
+  customElements.define('test-persistent-arc', TestPersistentArc);
+
+  describe('#update', function() {
+    function createTestArc() {
+      const arc = document.createElement('test-persistent-arc');
+      target.appendChild(arc);
+
+      // Create the arc's database key.
+      const props = { key: '*' };
+      const state = { db: db, watch: {} };
+      const lastProps = {};
+      arc._update(props, state, lastProps);
+
+      return arc;
+    }
+
+    it('should incorporate an external manifest specified via solo', function() {
+      const arc = createTestArc();
+      const soloPath = 'http://www.foo.com/solo.recipes';
+      arc.setSearchParam('solo', soloPath);
+
+      const state = arc._state;
+      const props = { key: state.key, metadata: {} };
+      assert.isUndefined(
+        state.db.child(state.key).child('metadata').lastUpdate
+      );
+      arc._update(props, state, {});
+      assert.equal(
+        state.db.child(state.key).child('metadata').lastUpdate.externalManifest,
+        soloPath
+      );
+    });
+
+    it('should incorporate an external manifest specified via manifest', function() {
+      const arc = createTestArc();
+      const manifestPath = 'http://www.foo.com/manifest.recipes';
+      arc.setSearchParam('manifest', manifestPath);
+
+      const state = arc._state;
+      const props = { key: state.key, metadata: {} };
+      assert.isUndefined(
+        state.db.child(state.key).child('metadata').lastUpdate
+      );
+      arc._update(props, state, {});
+      assert.equal(
+        state.db.child(state.key).child('metadata').lastUpdate.externalManifest,
+        manifestPath
+      );
+    });
+
+    it('should incorporate an external manifest prioritizing solo over manifest param', function() {
+      const arc = createTestArc();
+      const soloPath = 'http://www.foo.com/solo.recipes';
+      arc.setSearchParam('solo', soloPath);
+      const manifestPath = 'http://www.foo.com/manifest.recipes';
+      arc.setSearchParam('manifest', manifestPath);
+
+      const state = arc._state;
+      const props = { key: state.key, metadata: {} };
+      assert.isUndefined(
+        state.db.child(state.key).child('metadata').lastUpdate
+      );
+      arc._update(props, state, {});
+      assert.equal(
+        state.db.child(state.key).child('metadata').lastUpdate.externalManifest,
+        soloPath
+      );
+    });
+
+    it('should set a null external manifest when there is no solo or manifest param', function() {
+      const arc = createTestArc();
+
+      const state = arc._state;
+      const props = { key: state.key, metadata: {} };
+      assert.isUndefined(
+        state.db.child(state.key).child('metadata').lastUpdate
+      );
+      arc._update(props, state, {});
+      assert.isNull(
+        state.db.child(state.key).child('metadata').lastUpdate.externalManifest
+      );
+    });
+  });
+});

--- a/dev/artifacts/Arcs/ArcMetadata.schema
+++ b/dev/artifacts/Arcs/ArcMetadata.schema
@@ -15,3 +15,4 @@ schema ArcMetadata
     Boolean profile
   optional
     Text blurb
+    URL externalManifest

--- a/dev/components/xen/xen-base.js
+++ b/dev/components/xen/xen-base.js
@@ -1,7 +1,8 @@
 class XenBase extends XenElement(XenState(HTMLElement)) {
   get template() {
     // TODO(sjmiles): null check module?
-    return this.constructor.module.querySelector('template');
+    const module = this.constructor.module;
+    return module ? module.querySelector('template') : '';
   }
   get host() {
     return this.shadowRoot || this.attachShadow({mode: `open`});

--- a/dev/test/index.test.html
+++ b/dev/test/index.test.html
@@ -21,6 +21,21 @@ http://polymer.github.io/PATENTS.txt
 <script src="../apps/chrome-extension/data-processing.js"></script>
 <script src="../apps/chrome-extension/test/data-processing-test.js"></script>
 
+<script src="../app-shell/elements/test/fake-database.js"></script>
+<script src="../app-shell/elements/test/fake-database-test.js"></script>
+
+<script src="../components/xen/xen-state.js"></script>
+<script src="../components/xen/xen-element.js"></script>
+<script src="../components/xen/xen-base.js"></script>
+<script>window.Arcs = {};</script>
+<script src="../app-shell/lib/utils.js"></script>
+<!-- TODO(wkorman): Due to HTML imports below these tests must be served through
+an http server in order to run. If we shift them to JS modules then we can go
+back to serving from the file system. -->
+<link rel="import" href="../app-shell/elements/persistent-arc.html">
+<link rel="import" href="../app-shell/elements/watch-group.html">
+<script src="../app-shell/elements/test/persistent-arc-test.js"></script>
+
 <script src="selenium-utils.js"></script>
 <script src="selenium-utils-test.js"></script>
 <script>


### PR DESCRIPTION
Persist solo/manifest url in `ArcMetadata.additionalRecipe` and surface it in the app shell `ArcMetadata.href` and thus the arc links.

Also null-check the module before dereferencing in `xen-base.js`, which turned out to be necessary when loading html modules for unit testing.

Fixes #94 