### PR TITLE
more verbose test progress reporting

### DIFF
--- a/dev/test/wdio.conf.js
+++ b/dev/test/wdio.conf.js
@@ -131,9 +131,7 @@ exports.config = {
   framework: 'mocha',
   //
   // Test reporter for stdout.
-  // The only one supported by default is 'dot'
-  // see also: http://webdriver.io/guide/reporters/dot.html
-  reporters: ['dot'],
+  reporters: ['spec'],
 
   //
   // Options to be passed to Mocha.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mocha-chrome": "^1.0.2",
     "wdio-chromedriver-service": "^0.1.2",
     "wdio-mocha-framework": "^0.5.11",
+    "wdio-spec-reporter": "^0.1.3",
     "webdriverio": "^4.9.11",
     "webpack": "^2.6.1"
   },


### PR DESCRIPTION
The output now contains information about what tests are being run. It'd be nice if the test was passing, too.

There seems to be an incompatibility between my color scheme and the output colors, but that's easily fixed by selecting the text.

<img width="1123" alt="screen shot 2018-01-02 at 2 19 26 pm" src="https://user-images.githubusercontent.com/562883/34502370-059c43c4-efc8-11e7-853e-2c9d293a1dfa.png">
