### PR TITLE
Include external manifest in arc href.

### DIFF
--- a/dev/app-shell/elements/arc-app.html
+++ b/dev/app-shell/elements/arc-app.html
@@ -448,7 +448,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         let data = Object.keys(visited).map(key => {
           let {metadata, profile} = visited[key];
           let href = `${location.origin}${location.pathname}?arc=${key}&user=${user.id}`;
-          if (metadata.additionalRecipe) href += `&manifest=${metadata.additionalRecipe}`;
+          if (metadata.externalManifest) href += `&manifest=${metadata.externalManifest}`;
           return {
             key: key,
             description: metadata.description || key.slice(1),


### PR DESCRIPTION
I forgot to rename the `ArcMetadata.externalManifest` field reference in `arc-app.html` after renaming it in the schema and `persistent-arc.html` in https://github.com/PolymerLabs/arcs-cdn/commit/5ece67df20f9cc3af39918f98953b45e7c069034.

We're missing unit tests for `arc-app.html` and I looked at adding but it's a large class and since it's a field rename the unit test probably would have passed anyway unless we caught renaming it there as well, so am leaving test coverage for this as a future exercise for now.

Part of fixing https://github.com/PolymerLabs/arcs-cdn/issues/94