### PR TITLE
Remove old arc suggestion logic.

### DIFF
--- a/dev/app-shell/lib/utils.js
+++ b/dev/app-shell/lib/utils.js
@@ -76,12 +76,7 @@ let utils = {
     return `${rl(adjectives)}-${rl(nouns)}`.replace(/ /g, '-');
   },
   async describeArc(arc) {
-    let combinedSuggestion = await new Arcs.Description(arc).getArcDescription();
-    //let combinedSuggestion = Arcs.Description.getSuggestion(arc._activeRecipe, arc, null);
-    //if (combinedSuggestion) {
-    //  let tags = Object.keys(arc._tags).filter(t => ['#nosync','#arcmetadata','#identity','#identities'].indexOf(t) < 0);
-    //  combinedSuggestion += `${tags.length ? ` (${tags.join(", ")})` : ''}`;
-    //}
+    const combinedSuggestion = await new Arcs.Description(arc).getArcDescription();
     return combinedSuggestion || '';
   },
   removeUndefined(object) {


### PR DESCRIPTION
From discussion on https://github.com/PolymerLabs/arcs-cdn/commit/d1d989558e119b82bdce0d9c4f946038f56870e5

The code was commented out in https://github.com/PolymerLabs/arcs-cdn/commit/ca2a914b337328674ffb60c872268625ea22f705 and the kernel API has changed since then, so it feels like we may as well remove this and can resurrect from archive or otherwise recreate if needed.