### PR TITLE
Restore basic arc sharing functionality.

### DIFF
--- a/dev/app-shell/elements/arc-app.html
+++ b/dev/app-shell/elements/arc-app.html
@@ -148,7 +148,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </template>
         <div buttons style%="{{toolbarButtonsStyle}}">
           <toggle-button title="Arc Contains Profile Data" state="{{profileState}}" on-state="_onProfileState" icons="person_outline person"></toggle-button>
-          <toggle-button title="Share this Arc" state="{{sharingState}}" on-state="_onSharingState" icons="link supervisor_account"></toggle-button>
+          <toggle-button title="Share this Arc" state="{{sharedState}}" on-state="_onSharedState" icons="link supervisor_account"></toggle-button>
           <toggle-button title="Cast" on-state="_onCastState" icons="cast cast_connected"></toggle-button>
           <i on-click="_onNewArcClick">note_add</i>
         </div>

--- a/dev/apps/smoke-tests/persistent-arc/arc-app.html
+++ b/dev/apps/smoke-tests/persistent-arc/arc-app.html
@@ -151,7 +151,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </template>
         <div buttons style%="{{toolbarButtonsStyle}}">
           <toggle-button state="{{profileState}}" on-state="_onProfileState" icons="person_outline person"></toggle-button>
-          <toggle-button state="{{sharingState}}" on-state="_onSharingState" icons="link supervisor_account"></toggle-button>
+          <toggle-button state="{{sharingState}}" on-state="_onSharedState" icons="link supervisor_account"></toggle-button>
           <toggle-button on-state="_onCastState" icons="cast cast_connected"></toggle-button>
           <i on-click="_onNewClick">note_add</i>
         </div>

--- a/dev/artifacts/People/Person.schema
+++ b/dev/artifacts/People/Person.schema
@@ -17,3 +17,4 @@ schema Person extends Thing
     Text active
     Object arcs
     Object profiles
+    Object shares


### PR DESCRIPTION
Working on a unit test currently. Perhaps a selenium test would actually be better, like, click the sharing button and make sure you can make the arc shared (button state changes) and then un-share.