### PR TITLE
exit with errors from wdio

### DIFF
--- a/tools/wdio-wrapper
+++ b/tools/wdio-wrapper
@@ -20,7 +20,7 @@ process.argv.slice(2).forEach(wdioConfig => {
   const version = wdioConfig.split(path.sep)[0];
   console.log('running web tests on version', version);
 
-  spawnSync(
+  const ret = spawnSync(
     'wdio',
     [
       '-b',
@@ -29,4 +29,8 @@ process.argv.slice(2).forEach(wdioConfig => {
     ],
     { cwd: path.resolve(version), stdio: 'inherit' }
   );
+  if (ret.status>0) {
+    console.log(`exiting (status code ${ret.status}) due to errors in ${version}`);
+    process.exit(ret.status);
+  }
 });


### PR DESCRIPTION
This short-circuits out once a single error has been detected (so some
versions may not have their tests run).