### PR TITLE
Restore inclusion of external manifest in arc href.

### DIFF
--- a/dev/app-shell/elements/arc-app.html
+++ b/dev/app-shell/elements/arc-app.html
@@ -481,7 +481,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             description: metadata.description || key.slice(1),
             icon: metadata.icon || 'broken_image',
             color: metadata.color || 'gray',
-            href: `${location.origin}${location.pathname}?arc=${key}&user=${user.id}`,
+            href: href,
             profile: profile
           };
         });


### PR DESCRIPTION
https://github.com/PolymerLabs/arcs-cdn/commit/14a93dff7c4b65db242a553b130308bb4d20205f accidentally reverted the change in https://github.com/PolymerLabs/arcs-cdn/commit/5ece67df20f9cc3af39918f98953b45e7c069034

TODO(wkorman): Write a test for `arc-app.html` that includes an external manifest and checks the resulting href in the Arc element.