### PR TITLE
provide a mechanism to continue developing arcs-cdn even if the arcs

### DIFF
--- a/dev/gulpfile.js
+++ b/dev/gulpfile.js
@@ -11,6 +11,7 @@ const execSync = require('child_process').execSync;
 const path = require('path');
 const resolve = path.resolve;
 const sep = path.sep;
+const argv = require('yargs').argv;
 
 const target = `./lib`;
 
@@ -27,9 +28,27 @@ const sources = {
 };
 
 let arcsBuild = async (path) => {
-  const options = {cwd: resolve(path), stdio: 'inherit'};
-  await execSync('npm install', options);
-  await execSync(`node tools${sep}sigh.js`, options);
+  try {
+    const options = {cwd: resolve(path), stdio: 'inherit'};
+    await execSync('npm install', options);
+
+    await execSync(`node tools${sep}sigh.js`, options);
+  } catch(e) {
+    console.log(`error running arcs build`, e);
+
+    // allow the arcs-cdn build to be continued even if the arcs build is
+    // failing. This is ideally a rarer case (so it's an option, not the
+    // default); hopefully arcs is working, and it's hard to predict if
+    // arcs-cdn will work if the arcs upon which it's based is known to be
+    // failing.
+    if (!argv.ignoreArcFailure) {
+      throw Error(`********************
+  There was an error executing the arcs build.
+  To copy arcs-runtime despite the failure(not recommended), run 'gulp --ignore-arc-failure'.
+  Otherwise, fix the build issues in arcs and re-run.
+  ********************`);
+    }
+  }
 };
 
 gulp.task('arcs-build', async function() {
@@ -69,7 +88,7 @@ let pack = async (files) => {
   }
 };
 
-gulp.task('build', ['arcs-build'], async function() {
+gulp.task('copy-runtime', ['arcs-build'], async function() {
   await pack(sources.cdn);
 });
 
@@ -81,10 +100,9 @@ const strategyExplorer = `strategy-explorer`;
 const suggestionsElement = `suggestions-element.js`;
 const glob = `/**/*`;
 
-gulp.task('copy', function () {
+gulp.task('copy-support', ['arcs-build'], function () {
   gulp.src(`${arcs}${strategyExplorer}${glob}`).pipe(gulp.dest(`${components}${strategyExplorer}`));
   gulp.src(`${arcs}${browserlib}${suggestionsElement}`).pipe(gulp.dest(`${components}`));
 });
 
-gulp.task('default', ['build'/*,'copy'*/]);
-
+gulp.task('default', ['arcs-build', 'copy-runtime'/*,'copy-support'*/]);

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     "wdio-chromedriver-service": "^0.1.2",
     "wdio-mocha-framework": "^0.5.11",
     "wdio-spec-reporter": "^0.1.3",
-    "webdriverio": "^4.9.11",
-    "webpack": "^2.6.1"
+    "webdriverio": "^4.10.1",
+    "webpack": "^2.6.1",
+    "yargs": "^10.1.1"
   },
   "prettier": {
     "singleQuote": true


### PR DESCRIPTION
build is failing
- By running `gulp --ignore-arc-failure`, the arcs-cdn build will ignore
  any failures in the arcs build and will continue the arcs-cdn build
  (copying resources and running webpack). This isn't the default
  because I expect if the arcs build isn't working, neither will any
  arcs-cdn build based upon that.
- Update webdriver.io.