### PR TITLE
Import where required rather than in app shell.

### DIFF
--- a/dev/app-shell/app-shell.js
+++ b/dev/app-shell/app-shell.js
@@ -8,39 +8,5 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
-// Components.
-import "../components/xen/xen.js";
-import "../components/toggle-button.js";
-import "../components/arc-tools/arc-explorer.js";
-import "../components/arc-tools/explorer-hotkey.js";
-import "../components/arc-tools/local-data.js";
-import "../components/arc-tools/manifest-data.js";
-import "../components/arc-tools/shell-particles.js";
-import "../components/data-explorer.js";
-import "../components/simple-tabs.js";
-import "../components/suggestion-element.js";
-
-// Elements.
-import "./elements/arc-config.js";
-import "./elements/arc-footer.js";
-import "./elements/arc-handle.js";
-import "./elements/arc-host.js";
-import "./elements/arc-steps.js";
-import "./elements/arc-store.js";
-import "./elements/persistent-arc.js";
-import "./elements/persistent-handles.js";
-import "./elements/persistent-manifests.js";
-import "./elements/persistent-user.js";
-import "./elements/persistent-users.js";
-import "./elements/remote-friends-profile-handles.js";
-import "./elements/remote-profile-handles.js";
-import "./elements/remote-shared-handles.js";
-import "./elements/remote-visited-arcs.js";
-import "./elements/watch-group.js";
-
-import "../lib/ArcsLib.js";
+// TODO(wkorman): Rename arc-app to app-shell and kill this thing.
 import "./elements/arc-app.js";
-
-// For Particles (should be separate import?).
-import "../components/corellia-xen/cx-input.js";
-import "../components/good-map.js";

--- a/dev/app-shell/elements/arc-app.js
+++ b/dev/app-shell/elements/arc-app.js
@@ -9,7 +9,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
  */
 
 import ArcsUtils from "../lib/arcs-utils.js";
+import "../../components/arc-tools/arc-explorer.js";
+import "../../components/arc-tools/explorer-hotkey.js";
+import "../../components/arc-tools/local-data.js";
+import "../../components/arc-tools/manifest-data.js";
 import "../../components/arc-tools/shell-particles.js";
+import "../../components/data-explorer.js";
+import "../../components/simple-tabs.js";
+import "../../components/suggestion-element.js";
+import "../../components/toggle-button.js";
+import Xen from '../../components/xen/xen-template.js';
+import "./arc-config.js";
+import "./arc-footer.js";
+import "./arc-handle.js";
+import "./arc-host.js";
+import "./arc-steps.js";
+import "./arc-store.js";
+import "./persistent-arc.js";
+import "./persistent-handles.js";
+import "./persistent-manifests.js";
+import "./persistent-user.js";
+import "./persistent-users.js";
+import "./remote-friends-profile-handles.js";
+import "./remote-profile-handles.js";
+import "./remote-shared-handles.js";
+import "./remote-visited-arcs.js";
+
+// For particles.
+import "../../components/corellia-xen/cx-input.js";
+import "../../components/good-map.js";
+
+import XenBase from "../../components/xen/xen-base.js";
+
+import "../../lib/ArcsLib.js";
 
 const template = Object.assign(document.createElement('template'), {innerHTML:
 `<style>

--- a/dev/app-shell/elements/arc-config.js
+++ b/dev/app-shell/elements/arc-config.js
@@ -8,6 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+import XenBase from "../../components/xen/xen-base.js";
+
 class ArcConfig extends XenBase {
   static get observedAttributes() { return ['rootpath']; }
   _update(props, state, lastProps) {

--- a/dev/app-shell/elements/arc-footer.js
+++ b/dev/app-shell/elements/arc-footer.js
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import "../../components/dancing-dots.js";
 import "../../components/x-toast.js";
+import XenBase from "../../components/xen/xen-base.js";
 
 const template = Object.assign(document.createElement('template'), {innerHTML:
   `<style>

--- a/dev/app-shell/elements/arc-handle.js
+++ b/dev/app-shell/elements/arc-handle.js
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import ArcsUtils from "../lib/arcs-utils.js";
+import XenBase from "../../components/xen/xen-base.js";
 
 class ArcHandle extends XenBase {
   static get observedAttributes() { return ['arc', 'options', 'data']; }

--- a/dev/app-shell/elements/arc-host.js
+++ b/dev/app-shell/elements/arc-host.js
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import ArcsUtils from "../lib/arcs-utils.js";
+import XenBase from "../../components/xen/xen-base.js";
 
 const template = Object.assign(document.createElement('template'), {innerHTML:
   `<style>

--- a/dev/app-shell/elements/arc-steps.js
+++ b/dev/app-shell/elements/arc-steps.js
@@ -8,6 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+import XenBase from "../../components/xen/xen-base.js";
+
 class ArcSteps extends XenBase {
   static get observedAttributes() { return ['plans','plan','steps','step']; }
   _getInitialState() {

--- a/dev/app-shell/elements/persistent-arc.js
+++ b/dev/app-shell/elements/persistent-arc.js
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import WatchGroup from './watch-group.js';
 import ArcsUtils from "../lib/arcs-utils.js";
+import XenBase from "../../components/xen/xen-base.js";
 
 class PersistentArc extends XenBase {
   static get observedAttributes() { return ['key','metadata']; }

--- a/dev/app-shell/elements/persistent-handles.js
+++ b/dev/app-shell/elements/persistent-handles.js
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import ArcsUtils from "../lib/arcs-utils.js";
+import XenBase from "../../components/xen/xen-base.js";
 
 class PersistentHandles extends XenBase {
   static get observedAttributes() { return ['arc','key']; }

--- a/dev/app-shell/elements/persistent-manifests.js
+++ b/dev/app-shell/elements/persistent-manifests.js
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import WatchGroup from './watch-group.js';
+import XenBase from "../../components/xen/xen-base.js";
 
 class PersistentManifests extends XenBase {
   static get observedAttributes() { return ['manifests','exclusions']; }

--- a/dev/app-shell/elements/persistent-user.js
+++ b/dev/app-shell/elements/persistent-user.js
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import WatchGroup from './watch-group.js';
+import XenBase from "../../components/xen/xen-base.js";
 
 (scope => {
   class PersistentUser extends XenBase {

--- a/dev/app-shell/elements/persistent-users.js
+++ b/dev/app-shell/elements/persistent-users.js
@@ -8,6 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+import XenBase from "../../components/xen/xen-base.js";
+
 class PersistentUsers extends XenBase {
   static get observedAttributes() { return []; }
   _update(props, state, lastProps) {

--- a/dev/app-shell/elements/remote-friends-profile-handles.js
+++ b/dev/app-shell/elements/remote-friends-profile-handles.js
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import WatchGroup from './watch-group.js';
 import ArcsUtils from "../lib/arcs-utils.js";
+import XenBase from "../../components/xen/xen-base.js";
 
 class RemoteFriendsProfileHandles extends XenBase {
   static get observedAttributes() { return ['arc','friends','user']; }

--- a/dev/app-shell/elements/remote-profile-handles.js
+++ b/dev/app-shell/elements/remote-profile-handles.js
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import WatchGroup from './watch-group.js';
 import ArcsUtils from "../lib/arcs-utils.js";
+import XenBase from "../../components/xen/xen-base.js";
 
 class RemoteProfileHandles extends XenBase {
   static get observedAttributes() { return ['arc', 'user']; }

--- a/dev/app-shell/elements/remote-shared-handles.js
+++ b/dev/app-shell/elements/remote-shared-handles.js
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import WatchGroup from './watch-group.js';
 import ArcsUtils from "../lib/arcs-utils.js";
+import XenBase from "../../components/xen/xen-base.js";
 
 class RemoteSharedHandles extends XenBase {
   static get observedAttributes() { return ['arc','friends','user']; }

--- a/dev/app-shell/elements/remote-visited-arcs.js
+++ b/dev/app-shell/elements/remote-visited-arcs.js
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import WatchGroup from './watch-group.js';
+import XenBase from "../../components/xen/xen-base.js";
 
 class RemoteVisitedArcs extends XenBase {
   static get observedAttributes() { return ['user', 'arcs']; }

--- a/dev/app-shell/elements/watch-group.js
+++ b/dev/app-shell/elements/watch-group.js
@@ -8,6 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+import XenBase from "../../components/xen/xen-base.js";
+
 class WatchGroup extends XenBase {
   static get observedAttributes() { return ['watches','db']; }
   add(watches) {

--- a/dev/app-shell/lib/arcs-utils.js
+++ b/dev/app-shell/lib/arcs-utils.js
@@ -8,6 +8,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import XenBase from "../../components/xen/xen-base.js";
+
 class ArcsUtils {
   static createArc({id, urlMap, slotComposer, context, loader}) {
     // worker paths are relative to worker location, remap urls from there to here

--- a/dev/components/arc-tools/arc-explorer.js
+++ b/dev/components/arc-tools/arc-explorer.js
@@ -8,6 +8,9 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+import "../data-explorer.js";
+import XenBase from "../xen/xen-base.js";
+
 const template = Object.assign(document.createElement('template'), {innerHTML:
   `<style>
     arc-explorer > [banner] {

--- a/dev/components/arc-tools/local-data.js
+++ b/dev/components/arc-tools/local-data.js
@@ -8,6 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+import Xen from '../xen/xen-template.js';
+
 const template = Object.assign(document.createElement('template'), {innerHTML:
   `<style>
     local-data [banner] {

--- a/dev/components/arc-tools/manifest-data.js
+++ b/dev/components/arc-tools/manifest-data.js
@@ -8,6 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+import Xen from '../xen/xen-template.js';
+
 const template = Object.assign(document.createElement('template'), {innerHTML:
   `<style>
     manifest-data [banner] {

--- a/dev/components/arc-tools/shell-particles.js
+++ b/dev/components/arc-tools/shell-particles.js
@@ -8,6 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+import XenBase from "../xen/xen-base.js";
+
 class ShellParticles extends XenBase {
   static get observedAttributes() { return ['arc']; }
   _update(props, state, lastProps) {

--- a/dev/components/corellia-xen/cx-input.js
+++ b/dev/components/corellia-xen/cx-input.js
@@ -8,6 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+import XenBase from "../../components/xen/xen-base.js";
+
 const template = Object.assign(document.createElement('template'), {innerHTML:
   `<style>
     :host {

--- a/dev/components/data-explorer.js
+++ b/dev/components/data-explorer.js
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import './data-item.js';
+import XenBase from "./xen/xen-base.js";
 
 const template = Object.assign(document.createElement('template'), {innerHTML:
 `<style>

--- a/dev/components/data-item.js
+++ b/dev/components/data-item.js
@@ -8,6 +8,9 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+import "./data-explorer.js";
+import XenBase from "./xen/xen-base.js";
+
 const template = Object.assign(document.createElement('template'), {innerHTML:
   `<left title="{{name}}" on-click="_onExpandClick">{{name}}</left>
   <right>

--- a/dev/components/simple-tabs.js
+++ b/dev/components/simple-tabs.js
@@ -7,6 +7,9 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+
+import Xen from './xen/xen-template.js';
+
 const template = Object.assign(document.createElement('template'), {innerHTML:
   `<style>
     :host [crumbs] {

--- a/dev/components/toggle-button.js
+++ b/dev/components/toggle-button.js
@@ -7,6 +7,9 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
+
+import XenBase from "./xen/xen-base.js";
+
 const template = Object.assign(document.createElement('template'), {innerHTML:
 `<style>
     :host {

--- a/dev/components/xen/xen-base.js
+++ b/dev/components/xen/xen-base.js
@@ -1,5 +1,6 @@
 import XenState from "./xen-state.js";
 import XenElement from "./xen-element.js";
+import Xen from './xen-template.js';
 
 class XenBase extends XenElement(XenState(HTMLElement)) {
   get template() {

--- a/dev/components/xen/xen.js
+++ b/dev/components/xen/xen.js
@@ -3,12 +3,6 @@ import XenState from "./xen-state.js";
 import XenElement from "./xen-element.js";
 import XenBase from "./xen-base.js";
 
-// TODO(sjmiles): for backward-compatibility only
-window.Xen = XenTemplate;
-window.XenState = XenState;
-window.XenElement = XenElement;
-window.XenBase = XenBase;
-
 export default {
   XenState,
   XenTemplate,


### PR DESCRIPTION
Addresses the Xen window globals and localized dependencies portions of https://github.com/PolymerLabs/arcs-cdn/issues/142