### PR TITLE
run webpack before test

### DIFF
--- a/dev/gulpfile.js
+++ b/dev/gulpfile.js
@@ -32,7 +32,8 @@ let arcsBuild = async (path) => {
     const options = {cwd: resolve(path), stdio: 'inherit'};
     await execSync('npm install', options);
 
-    await execSync(`node tools${sep}sigh.js`, options);
+    await execSync(`node tools${sep}sigh.js webpack`, options);
+    await execSync(`node tools${sep}sigh.js test`, options);
   } catch(e) {
     console.log(`error running arcs build`, e);
 
@@ -41,6 +42,8 @@ let arcsBuild = async (path) => {
     // default); hopefully arcs is working, and it's hard to predict if
     // arcs-cdn will work if the arcs upon which it's based is known to be
     // failing.
+    // We detect the error here and log instead of skipping the test run above
+    // so there's a record of the action and specific failure.
     if (!argv.ignoreArcFailure) {
       throw Error(`********************
   There was an error executing the arcs build.

--- a/dev/gulpfile.js
+++ b/dev/gulpfile.js
@@ -10,7 +10,7 @@ const gulp = require('gulp');
 const execSync = require('child_process').execSync;
 const path = require('path');
 const resolve = path.resolve;
-const sep = path.sep;
+const normalize = path.normalize;
 const argv = require('yargs').argv;
 
 const target = `./lib`;
@@ -32,8 +32,9 @@ let arcsBuild = async (path) => {
     const options = {cwd: resolve(path), stdio: 'inherit'};
     await execSync('npm install', options);
 
-    await execSync(`node tools${sep}sigh.js webpack`, options);
-    await execSync(`node tools${sep}sigh.js test`, options);
+    const sigh = normalize('tools/sigh.js');
+    await execSync(`node ${sigh} webpack`, options);
+    await execSync(`node ${sigh} test`, options);
   } catch(e) {
     console.log(`error running arcs build`, e);
 


### PR DESCRIPTION
This allows the build to be continued even when there are test failures
in arcs. But, by default, a test failure will block the arcs-cdn build
so we don't base arcs-cdn off of a known bad version of arcs.