### PR TITLE
remove the ${target} prefix from copy-support

### DIFF
--- a/dev/gulpfile.js
+++ b/dev/gulpfile.js
@@ -98,7 +98,7 @@ gulp.task('pack', async function() {
 
 gulp.task('copy-runtime', ['arcs-build', 'pack']);
 
-const components = `${target}components/`;
+const components = `components/`;
 const arcs = `../../arcs/`;
 const browserlib = `runtime/browser/lib/`;
 


### PR DESCRIPTION
This was causing the strategy-explorer to be in a different directory
(libcomponents instead of components).



It looks like we hadn't updated strategy-explorer in a while, the copies were going to the wrong directory. That's fixed up here.