### PR TITLE
add 'search' attribute to the search button so the tests can find it

### DIFF
--- a/dev/app-shell/elements/arc-footer.js
+++ b/dev/app-shell/elements/arc-footer.js
@@ -53,7 +53,7 @@ const template = Xen.Template.createTemplate(
   <x-toast app-footer open="{{toastOpen}}" suggestion-container>
     <dancing-dots slot="toast-header" disabled="{{dotsDisabled}}" active="{{dotsActive}}"></dancing-dots>
     <div search>
-      <i class="material-icons" on-click="_onSearchClick">search</i>
+      <i class="material-icons" on-click="_onSearchClick" search>search</i>
       <input placeholder="Search" value="{{searchText}}" on-keypress="_onKeypress" on-input="_onSearchChange" on-blur="_onSearchCommit">
       <i class="material-icons" on-click="_onSearchClick">add</i>
     </div>

--- a/dev/app-shell/elements/arc-footer.js
+++ b/dev/app-shell/elements/arc-footer.js
@@ -53,7 +53,7 @@ const template = Xen.Template.createTemplate(
   <x-toast app-footer open="{{toastOpen}}" suggestion-container>
     <dancing-dots slot="toast-header" disabled="{{dotsDisabled}}" active="{{dotsActive}}"></dancing-dots>
     <div search>
-      <i class="material-icons" on-click="_onSearchClick" search>search</i>
+      <i class="material-icons" on-click="_onSearchClick" data-search>search</i>
       <input placeholder="Search" value="{{searchText}}" on-keypress="_onKeypress" on-input="_onSearchChange" on-blur="_onSearchCommit">
       <i class="material-icons" on-click="_onSearchClick">add</i>
     </div>

--- a/dev/app-shell/elements/arc-footer.js
+++ b/dev/app-shell/elements/arc-footer.js
@@ -53,7 +53,7 @@ const template = Xen.Template.createTemplate(
   <x-toast app-footer open="{{toastOpen}}" suggestion-container>
     <dancing-dots slot="toast-header" disabled="{{dotsDisabled}}" active="{{dotsActive}}"></dancing-dots>
     <div search>
-      <i class="material-icons" on-click="_onSearchClick" data-search>search</i>
+      <i class="material-icons" on-click="_onSearchClick" id="search-button">search</i>
       <input placeholder="Search" value="{{searchText}}" on-keypress="_onKeypress" on-input="_onSearchChange" on-blur="_onSearchCommit">
       <i class="material-icons" on-click="_onSearchClick">add</i>
     </div>

--- a/dev/test/specs/starter-test.js
+++ b/dev/test/specs/starter-test.js
@@ -261,7 +261,7 @@ function allSuggestions() {
   openSuggestionDrawer();
 
   const magnifier = pierceShadowsSingle(
-    getFooterPath().concat(['div[search]', 'i[data-search]'])
+    getFooterPath().concat(['div[search]', 'i#search-button'])
   );
   console.log(`click: allSuggestions`);
   browser.elementIdClick(magnifier.value.ELEMENT);

--- a/dev/test/specs/starter-test.js
+++ b/dev/test/specs/starter-test.js
@@ -261,7 +261,7 @@ function allSuggestions() {
   openSuggestionDrawer();
 
   const magnifier = pierceShadowsSingle(
-    getFooterPath().concat(['div[search]', 'i[search]'])
+    getFooterPath().concat(['div[search]', 'i[data-search]'])
   );
   console.log(`click: allSuggestions`);
   browser.elementIdClick(magnifier.value.ELEMENT);


### PR DESCRIPTION
In #186 I moved away from relying on `i:first-child`; I was worried that relying on our page structure to find the search element would continue to be brittle. I added a `search` attribute I could use instead, but given that in your removal cl (6c0c2964db1a81dd438047bd376b30176a2d2eed) you mentioned it was bogus there was probably impact from that.

I don't have a strong opinion regarding the correctness of this approach, though. Maybe it's better with the `data-` prefix? Or, if there's no other option, I could switch back to `:first-child` or maybe a search on the text contents.