### PR TITLE
Toast header: cursor pointer and user-select: none.

### DIFF
--- a/dev/components/x-toast.js
+++ b/dev/components/x-toast.js
@@ -32,6 +32,8 @@ const template = Xen.Template.createTemplate(`
     text-align: center;
     background-color: white;
     box-sizing: border-box;
+    cursor: pointer;
+    user-select: none;
   }
 </style>
 <div header><slot name="toast-header"></slot></div>


### PR DESCRIPTION
I noticed I could drag-select whitespace between dots. I started out setting this in `dancing-dots.js` but found that element doesn't fill the whole header horizontally.